### PR TITLE
Avoids sending two newlines between metrics

### DIFF
--- a/src/main/java/com/myfitnesspal/kafka/StatsdReporter.java
+++ b/src/main/java/com/myfitnesspal/kafka/StatsdReporter.java
@@ -314,7 +314,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 			statTypeStr = "ms";
 			break;
 		}
-		final String messageFormat = "%s%s:%s|%s\n";
+		final String messageFormat = "%s%s:%s|%s";
 		statsdClient.doSend(String.format(locale, messageFormat, prefix, sanitizeString(name), value, statTypeStr));
 	}
 


### PR DESCRIPTION
Currently both [the formatted string itself](https://github.com/myfitnesspal/kafka-statsd-reporter/blob/527a851957fba40ff0f334107a691b55e8a5c051/src/main/java/com/myfitnesspal/kafka/StatsdReporter.java#L317) _and_ [the `doSend` method](https://github.com/myfitnesspal/kafka-statsd-reporter/blob/527a851957fba40ff0f334107a691b55e8a5c051/src/main/java/com/myfitnesspal/kafka/StatsdReporter.java#L475-L478) add newlines after and before the metric, respectively.

The end result is that metrics have two newlines between them. Example package dump from our staging environment:

```
  6b 61 66 6b 61 2e 6b 61    66 6b 61 2e 73 65 72 76    kafka.kafka.serv
  65 72 2e 52 65 70 6c 69    63 61 4d 61 6e 61 67 65    er.ReplicaManage
  72 2e 50 61 72 74 69 74    69 6f 6e 43 6f 75 6e 74    r.PartitionCount
  3a 35 37 35 7c 67 0a 0a    6b 61 66 6b 61 2e 6b 61    :575|g..kafka.ka
  66 6b 61 2e 73 65 72 76    65 72 2e 52 65 70 6c 69    fka.server.Repli
  63 61 4d 61 6e 61 67 65    72 2e 55 6e 64 65 72 52    caManager.UnderR
  65 70 6c 69 63 61 74 65    64 50 61 72 74 69 74 69    eplicatedPartiti
  6f 6e 73 3a 30 7c 67 0a    0a 6b 61 66 6b 61 2e 6b    ons:0|g..kafka.k
  [.. more of the packet elided ..]
```

Note the double newline (`0a 0a`) between each metric.

Stricter parsers like [brubeck](https://github.com/github/brubeck) do consider this an error.