### PR TITLE
Added a config option to allow the Statsd client to be reused every t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Here is a list of default properties used:
     # since kafka has quite a lot of metrics, it is useful
     # if you have many topics/partitions.
     kafka.statsd.metrics.exclude.regex=<not set>
+    # Environments with frequent IP address changes (AWS) might not want to re-use the Statsd client between runs
+    kafka.statsd.metrics.client.reuse=true
 
 Usage As Lib
 -----------

--- a/src/main/java/com/myfitnesspal/kafka/KafkaStatsdMetricsReporter.java
+++ b/src/main/java/com/myfitnesspal/kafka/KafkaStatsdMetricsReporter.java
@@ -75,6 +75,8 @@ public class KafkaStatsdMetricsReporter implements KafkaMetricsReporter,
 			statsdPort = props.getInt("kafka.statsd.metrics.port", STATSD_DEFAULT_PORT);
 			statsdGroupPrefix = props.getString("kafka.statsd.metrics.group", STATSD_DEFAULT_PREFIX).trim();
             String regex = props.getString("kafka.statsd.metrics.exclude.regex", null);
+			boolean reuseStatsdClient = props.getBoolean("kafka.statsd.metrics.client.reuse", true);
+
 
             LOG.debug("Initialize StatsdReporter ["+statsdHost+","+statsdPort+","+statsdGroupPrefix+"]");
 
@@ -90,6 +92,7 @@ public class KafkaStatsdMetricsReporter implements KafkaMetricsReporter,
             			statsdPort,
             			Clock.defaultClock()
             			);
+            	reporter.setReuseStatsdClient(reuseStatsdClient);
             } catch (IOException e) {
             	LOG.error("Unable to initialize StatsdReporter", e);
             }

--- a/src/main/java/com/myfitnesspal/kafka/StatsdReporter.java
+++ b/src/main/java/com/myfitnesspal/kafka/StatsdReporter.java
@@ -40,6 +40,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 	protected final Clock clock;
 	protected final String host;
 	protected final int port;
+	private boolean reuseStatsdClient = true;
 	protected final VirtualMachineMetrics vm;
 	protected StatsdClient statsdClient;
 	public boolean printVMMetrics = true;
@@ -271,7 +272,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 	@Override
 	public void run() {
 		try {
-			if (statsdClient == null) {
+			if (statsdClient == null || reuseStatsdClient == false) {
 				statsdClient = new StatsdClient(host, port, STATSD_BUFFER);
 			}
 			final long epoch = clock.time() / 1000;
@@ -437,6 +438,10 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 
 	private String format(double v) {
 		return String.format(locale, "%2.2f", v);
+	}
+
+	public void setReuseStatsdClient(boolean reuseStatsdClient) {
+		this.reuseStatsdClient = reuseStatsdClient;
 	}
 
 	private class StatsdClient {


### PR DESCRIPTION
…ime (default) OR be instantiated

every time the metrics reporter is called.  This solves a problem in environments where the IP address
of the graphite server can change after Kafka is started (like AWS environments).  Without this flag, if
the IP address of the graphite server changes, you must bounce Kafka to get metrics.